### PR TITLE
Fix LocalDateTypeConverter package name

### DIFF
--- a/app/src/main/java/com/group7/g7_trivia_game/database/typeconverters/LocalDateTypeConverter.java
+++ b/app/src/main/java/com/group7/g7_trivia_game/database/typeconverters/LocalDateTypeConverter.java
@@ -1,5 +1,5 @@
 
-package com.example.hw03gymlog.database.typeConverters;
+package com.group7.g7_trivia_game.database.typeconverters;
 
 import androidx.room.TypeConverter;
 


### PR DESCRIPTION
The package name for the `LocalDateTypeConverter` class was corrected from `com.example.hw03gymlog.database.typeConverters` to `com.group7.g7_trivia_game.database.typeconverters`.