### PR TITLE
Annotate AnsweredQuestion entity with primary key

### DIFF
--- a/app/src/main/java/com/group7/g7_trivia_game/database/AnsweredQuestionDao.java
+++ b/app/src/main/java/com/group7/g7_trivia_game/database/AnsweredQuestionDao.java
@@ -40,7 +40,7 @@ public interface AnsweredQuestionDao {
 
     // Get a specific answered question by questionId and userId
     @Query("SELECT * FROM " + TriviaDatabase.ANSWERED_QUESTION_TABLE + " WHERE questionId = :questionId AND userId = :userId")
-    LiveData<User> getAnsweredQuestion(int questionId, int userId);
+    LiveData<AnsweredQuestion> getAnsweredQuestion(int questionId, int userId);
 
     // Get all answered questions by userId, ordered by dateAnswered
     @Query("SELECT * FROM " + TriviaDatabase.ANSWERED_QUESTION_TABLE + " WHERE userId = :userId ORDER BY dateAnswered DESC")

--- a/app/src/main/java/com/group7/g7_trivia_game/database/entities/AnsweredQuestion.java
+++ b/app/src/main/java/com/group7/g7_trivia_game/database/entities/AnsweredQuestion.java
@@ -1,6 +1,7 @@
 package com.group7.g7_trivia_game.database.entities;
 
 import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 import com.group7.g7_trivia_game.database.TriviaDatabase;
 
@@ -20,6 +21,7 @@ public class AnsweredQuestion {
     /**
      * Required fields: answeredQuestionId, userId, questionId, date answered, numberOfTries
      */
+    @PrimaryKey(autoGenerate = true)
     private int answeredQuestionId;
     private int userId;
     private int questionId;


### PR DESCRIPTION
The `answeredQuestionId` field in the `AnsweredQuestion` entity has been annotated with `@PrimaryKey(autoGenerate = true)` to designate it as the primary key with auto-increment functionality.

Additionally, the `getAnsweredQuestion` method in `AnsweredQuestionDao` has been corrected to return `LiveData<AnsweredQuestion>` instead of `LiveData<User>`.