### PR TITLE
Modify activities to finish instead of returning to main

### DIFF
--- a/app/src/main/java/com/group7/g7_trivia_game/CreateQuestionActivity.java
+++ b/app/src/main/java/com/group7/g7_trivia_game/CreateQuestionActivity.java
@@ -40,7 +40,7 @@ public class CreateQuestionActivity extends AppCompatActivity {
 
         //Button listeners for returning to the main activity
         binding.createQuestionBackButton.setOnClickListener(v -> {
-            returnToMain();
+            finish();
         });
 
         binding.createQuestionSubmitButton.setOnClickListener(v -> {

--- a/app/src/main/java/com/group7/g7_trivia_game/QuestionAnsweringActivity.java
+++ b/app/src/main/java/com/group7/g7_trivia_game/QuestionAnsweringActivity.java
@@ -44,7 +44,7 @@ public class QuestionAnsweringActivity extends AppCompatActivity {
 
         //Button listener for back button, returning to the main activity
         binding.backButton.setOnClickListener(v -> {
-            startActivity(IntentFactory.mainActivityIntentFactory(getApplicationContext(), userId));
+           finish();
         });
 
         //Observe the list of all question IDs


### PR DESCRIPTION
In `CreateQuestionActivity` and `QuestionAnsweringActivity`, the back buttons now call `finish()` to close the current activity and return to the previous one in the stack, instead of explicitly starting `MainActivity`.