### PR TITLE
Update Welcome Menu button to return to MainActivity

### DIFF
--- a/app/src/main/java/com/group7/g7_trivia_game/AdminActivity.java
+++ b/app/src/main/java/com/group7/g7_trivia_game/AdminActivity.java
@@ -57,7 +57,8 @@ public class AdminActivity extends AppCompatActivity {
             startActivity(intent);
         });
         binding.welcomeMenuButton.setOnClickListener(v -> {
-            finish(); // returns to previous screen
+            Intent intent = new Intent(AdminActivity.this, MainActivity.class);
+            startActivity(intent);
         });
     }
 }


### PR DESCRIPTION
The Welcome Menu button in AdminActivity now explicitly navigates back to MainActivity instead of simply finishing the current activity. If you went to create question then go to welcome menu it takes you back to previous activity. Made it specifically go to main activity only. 